### PR TITLE
Fix Docker build for Vite client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+client/node_modules
+client/dist
+npm-debug.log
+Dockerfile
+.dockerignore
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+client/node_modules/
+client/dist/
+.DS_Store
+.env
+*.log
+npm-debug.log*
+package-lock.json
+client/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,14 @@ FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --production
+
 COPY client/package*.json ./client/
-RUN cd client && npm install && npm run build
+RUN cd client && npm install
+
 COPY server ./server
-COPY client/dist ./client/dist
+COPY client ./client
+RUN cd client && npm run build
+
 
 # Production image
 FROM node:18-alpine


### PR DESCRIPTION
## Summary
- copy entire `client` directory before running `npm run build`
- add `.dockerignore` and `.gitignore`

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_6889a6fa736083229aac6651e45fe717